### PR TITLE
Use jsconfig instead of tsconfig

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "ES6",
     "module": "commonjs",
-    "allowJs": true,
     "checkJs": true,
     "outDir": "out",
     "rootDir": "src",


### PR DESCRIPTION
Automatic type aqcuisition  is not enabled in TypeScript project by default (ones defined by a `tsconfig.json`)